### PR TITLE
Fix ip_forwarding (issue #150 and 151)

### DIFF
--- a/vuurmuur/vuurmuur/createrule.c
+++ b/vuurmuur/vuurmuur/createrule.c
@@ -4520,20 +4520,26 @@ post_rules(const int debuglvl, struct vrmr_config *conf, /*@null@*/RuleSet *rule
             vrmr_debug(__FUNC__, "Enabling ip-forwarding because "
                     "forwarding rules were created.");
 
-        result = sysctl_exec(debuglvl, conf, "net.ipv4.ip_forward", "1", conf->bash_out);
-        if (result != 0)
-        {
-            /* if it fails, we dont really care, its not fatal */
-            vrmr_error(-1, "Error", "enabling ip-forwarding failed.");
-        }
+	if (ruleset->ipv == VRMR_IPV4)
+	{
+	    result = sysctl_exec(debuglvl, conf, "net.ipv4.ip_forward", "1", conf->bash_out);
+	    if (result != 0)
+	    {
+		/* if it fails, we dont really care, its not fatal */
+		vrmr_error(-1, "Error", "enabling ip-forwarding failed.");
+	    }
+	}
 
 #ifdef IPV6_ENABLED
-        result = sysctl_exec(debuglvl, conf, "net.ipv6.conf.all.forwarding", "1", conf->bash_out);
-        if (result != 0)
-        {
-            /* if it fails, we dont really care, its not fatal */
-            vrmr_error(-1, "Error", "enabling ip-forwarding for ipv6 failed.");
-        }
+	else
+	{
+	    result = sysctl_exec(debuglvl, conf, "net.ipv6.conf.all.forwarding", "1", conf->bash_out);
+	    if (result != 0)
+	    {
+		/* if it fails, we dont really care, its not fatal */
+		vrmr_error(-1, "Error", "enabling ip-forwarding for ipv6 failed.");
+	    }
+	}
 #endif
     }
     else
@@ -4544,20 +4550,26 @@ post_rules(const int debuglvl, struct vrmr_config *conf, /*@null@*/RuleSet *rule
             vrmr_debug(__FUNC__, "Disabling ip-forwarding because no "
                     "forwarding rules were created.");
 
-        result = sysctl_exec(debuglvl, conf, "net.ipv4.ip_forward", "0", conf->bash_out);
-        if (result != 0)
-        {
-            /* if it fails, we dont really care, its not fatal */
-            vrmr_error(-1, "Error", "enabling ip-forwarding failed.");
-        }
+	if (ruleset->ipv == VRMR_IPV4)
+	{
+	    result = sysctl_exec(debuglvl, conf, "net.ipv4.ip_forward", "0", conf->bash_out);
+	    if (result != 0)
+	    {
+		/* if it fails, we dont really care, its not fatal */
+		vrmr_error(-1, "Error", "enabling ip-forwarding failed.");
+	    }
+	}
 
 #ifdef IPV6_ENABLED
-        result = sysctl_exec(debuglvl, conf, "net.ipv6.conf.all.forwarding", "0", conf->bash_out);
-        if (result != 0)
-        {
-            /* if it fails, we dont really care, its not fatal */
-            vrmr_error(-1, "Error", "enabling ip-forwarding for ipv6 failed.");
-        }
+	else
+	{
+	    result = sysctl_exec(debuglvl, conf, "net.ipv6.conf.all.forwarding", "0", conf->bash_out);
+	    if (result != 0)
+	    {
+		/* if it fails, we dont really care, its not fatal */
+		vrmr_error(-1, "Error", "enabling ip-forwarding for ipv6 failed.");
+	    }
+	}
 #endif
     }
 


### PR DESCRIPTION
I want to use vuurmuur 0.8rc1, so I retrieve the latest code from GitHub and compile everything. But there was one important bug that was preventing me of using this latest version. The flag ip_forwarding was disabled.

I reviewed the code and the function post_rules (found in createrule.c) is called twice. Once for IPv4 and once for IPv6. I use only IPv4 rules. While debugging I found out that the first time ip_forward was set and the second time it was reset. There was no check in the function if the function call was made for IPv4 or IPv6.

This solution works for me.
