### PR TITLE
Tickets/155

### DIFF
--- a/vuurmuur/debian/vuurmuur.init
+++ b/vuurmuur/debian/vuurmuur.init
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+### BEGIN INIT INFO
+# Provides:        vuurmuur
+# Required-Start:  $syslog $network $local_fs
+# Required-Stop:   $syslog $network $local_fs
+# Should-Start:
+# Should-Stop:
+# Default-Start:   1 2 3 4 5
+# Default-Stop:        0 6
+# Short-Description:   Starts the Vuurmuur Firewall.
+# Description:     Vuurmuur is a middle-end and frontend for netfilter.
+### END INIT INFO
+
 # This is an implementation of a start-script for Vuurmuur.
 #
 # (c) 2004 Victor Julien, released under GPL.


### PR DESCRIPTION
Hello,

This backport fixes http://www.vuurmuur.org/trac/ticket/155

Julian
```
nsserv: warning: script 'vuurmuur' missing LSB tags and overrides
insserv: There is a loop between service php-fastcgi and vuurmuur if stopped
insserv: loop involving service vuurmuur at depth 2
insserv: loop involving service php-fastcgi at depth 1
insserv: Stopping vuurmuur depends on php-fastcgi and therefore on system facility `$all' which can not be true!
insserv: exiting now without changing boot order!
update-rc.d: error: insserv rejected the script header
dpkg: error processing vuurmuur (--configure):
subprocess installed post-installation script returned error exit status 1
dpkg: dependency problems prevent configuration of vuurmuur-conf:
vuurmuur-conf depends on vuurmuur; however:
Package vuurmuur is not configured yet.
dpkg: error processing vuurmuur-conf (--configure):
dependency problems - leaving unconfigured
Errors were encountered while processing:
vuurmuur
vuurmuur-conf
```