### PR TITLE
Fix parsing of 5-digit lower ports in port ranges

### DIFF
--- a/lib/services.c
+++ b/lib/services.c
@@ -513,31 +513,15 @@ vrmr_split_portrange(char *portrange, int *lowport, int *highport)
     *highport = 0;
 
     /* now split */
-    for(; count < strlen(portrange) && low_count < sizeof(low) - 1 && high_count < sizeof(high) - 1; count++)
-    {
-        if (portrange[count] != ':' && !isdigit(portrange[count]))
-            continue;
-
-        if(portrange[count] == ':')
-        {
-            range = TRUE;
-            low[count] = '\0';
-            continue;
-        }
-
-        if(range == FALSE)
-        {
-            low[low_count] = portrange[count];
-            low_count++;
-        }
-        else
-        {
-            high[high_count] = portrange[count];
-            high_count++;
-        }
-    }
-
+    for(; isdigit(portrange[count]) && low_count < sizeof(low) - 1; low_count++, count++)
+        low[low_count] = portrange[count];
     low[low_count]='\0';
+
+    if (portrange[count] == ':') {
+        count++;
+        for(; isdigit(portrange[count]) && high_count < sizeof(high) - 1; high_count++, count++)
+            high[high_count] = portrange[count];
+    }
     high[high_count]='\0';
 
     /*


### PR DESCRIPTION
In commit 749e137 (lib: various fixes and cleanups), a range check in
vrmr_split_portrange was changed to prevent overflowing a buffer.
However, this check now fires early when parsing a range where the lower
port has 5 digits, making it skip the upper port (e.g. "12345:23456" is
parsed as "12345").

The problem is that the loop checked for "low_count < sizeof(low) - 1",
which checks to see if there is still room for writing another byte to
the "low" buffer. This is appropriate when parsing the low port, but
once it is finished, and no more bytes need to be written to the low
buffer, the check is too strict, preventing parsing of the high port
number.

Instead of further complicating this already complex loop test, this
commit splits the parsing of the low and high port in separate loops,
which fixes this issue and simplifies the code.