### PR TITLE
rules: fix CT input rule missing protocol

### DIFF
--- a/vuurmuur/createrule.c
+++ b/vuurmuur/createrule.c
@@ -474,8 +474,8 @@ int create_rule_input(struct vrmr_config *conf, struct rule_scratch *rule,
                     (iptcap->table_raw == TRUE && iptcap->target_ct == TRUE)) &&
             (rule->ipv == VRMR_IPV4 || strcmp(rule->helper, "irc") != 0)) {
         snprintf(cmd, sizeof(cmd),
-                "%s %s %s %s %s %s -m connmark --mark 0 -j CT --helper %s",
-                input_device, rule->temp_src, rule->temp_src_port,
+                "%s %s %s %s %s %s %s -m connmark --mark 0 -j CT --helper %s",
+                input_device, rule->proto, rule->temp_src, rule->temp_src_port,
                 rule->temp_dst, rule->temp_dst_port, rule->from_mac,
                 rule->helper);
 


### PR DESCRIPTION
This would lead to iptables-restore rejecting the rule and refusing to
load the ruleset.